### PR TITLE
Simplify pipeline and build images in memory

### DIFF
--- a/omnipose_pipeline.py
+++ b/omnipose_pipeline.py
@@ -1,51 +1,7 @@
 import os
-import make_multi_channels
 import omnipose_threaded
 import process_masks
-import time
-import threading
-import queue
 from importlib.resources import files
-import measure_growth_rates
-import subprocess
-
-def producer(inputDir, subdir, outputDir, queue):
-    subdir = make_multi_channels.make_multi_channels_reorder(inputDir, subdir, outputDir, 4)
-    queue.put(subdir)
-
-def producer_worker(inputDir, outputDir, dir_queue):
-    subdirs = [d for d in os.listdir(inputDir) if os.path.isdir(os.path.join(inputDir, d)) and not "epoch" in d]
-    
-    for subdir in subdirs:
-        while dir_queue.full():
-            time.sleep(0.25)
-
-        producer(inputDir, subdir, outputDir, dir_queue)
-    
-    dir_queue.put(None)
-
-def consumer(outputDir, lock, queue):
-    while True:
-        subdir = queue.get()
-        if subdir is None:
-            break
-
-        merged_img_dir = os.path.join(outputDir, subdir)
-        dead_dir = None
-        for model_info_array in PRETRAINED_MODEL_INFOS:
-            try:
-                live_dir = omnipose_threaded.run_omnipose(merged_img_dir, model_info_array, num_threads=8, save_flows=True)
-                results_csv = process_masks.process_mask_files(live_dir, CM_PER_PIXEL, PLATE_AREAS.get(PLATE_TYPE), force_save=False, filter_min_size=None)
-            except Exception as e:
-                print(f"Error processing directory {merged_img_dir} with {model_info_array}: {e}")
-        if DEAD_MODEL_INFO:
-            try:
-                dead_dir = omnipose_threaded.run_omnipose(merged_img_dir, DEAD_MODEL_INFO[0], num_threads=8)
-                results_csv = process_masks.process_mask_files(dead_dir, CM_PER_PIXEL, PLATE_AREAS.get(PLATE_TYPE), force_save=False, filter_min_size=None)
-            except Exception as e:
-                print(f"Error processing directory {merged_img_dir} with dead model: {e}")
-
-        queue.task_done()
 
 PLATE_TYPE = "96W"
 MAGNIFICATION = "10x"
@@ -56,78 +12,72 @@ if CYTATION:
     MICRONS_PER_PIXEL = 1389 / 1992 if MAGNIFICATION == "10x" else 694 / 1992
     IMAGE_AREA_CM = 1992 * 1992 * MICRONS_PER_PIXEL**2 * CM_PER_MICRON**2
 else:
-    if MAGNIFICATION=="10x":
-        MICRONS_PER_PIXEL = 0.61922571983322461  # Taken from image metadata EVOS 10x
-        IMAGE_AREA_CM = 0.0120619953 # Taken from image metadata EVOS 10x
+    if MAGNIFICATION == "10x":
+        MICRONS_PER_PIXEL = 0.61922571983322461
+        IMAGE_AREA_CM = 0.0120619953
     else:
-        MICRONS_PER_PIXEL = 1.5188172690164046  # Taken from image metadata EVOS 4x
-        IMAGE_AREA_CM = 0.0725658405  # Taken from image metadata EVOS 4x
+        MICRONS_PER_PIXEL = 1.5188172690164046
+        IMAGE_AREA_CM = 0.0725658405
 
-CM_PER_PIXEL = CM_PER_MICRON*MICRONS_PER_PIXEL
-
+CM_PER_PIXEL = CM_PER_MICRON * MICRONS_PER_PIXEL
 
 PRETRAINED_MODEL_INFOS = [
-    [str(files("clonalisa").joinpath("omnipose_models") / r"10x_NPC_nclasses_2_nchan_3_dim_2_2024_03_29_02_03_10.875324_epoch_960"), 0.4, 0],
+    [str(files("clonalisa").joinpath("omnipose_models") /
+         "10x_NPC_nclasses_2_nchan_3_dim_2_2024_03_29_02_03_10.875324_epoch_960"), 0.4, 0],
 ]
 
 DEAD_MODEL_INFO = [
-    [str(files("clonalisa").joinpath("omnipose_models") / r"dead_nclasses_2_nchan_3_dim_2_ded_2025_03_07_02_10_15.252341_epoch_3999"), 0.4, 0],
+    [str(files("clonalisa").joinpath("omnipose_models") /
+         "dead_nclasses_2_nchan_3_dim_2_ded_2025_03_07_02_10_15.252341_epoch_3999"), 0.4, 0],
 ]
-    
-def main():
-    inputDirs = [r"E:\test"]
 
-    for inputDir in inputDirs:
+CHANNEL_ORDER = [1, 2, 0]
+
+
+def process_directory(input_dir: str) -> None:
+    subdirs = [d for d in os.listdir(input_dir)
+               if os.path.isdir(os.path.join(input_dir, d)) and "epoch" not in d]
+    for subdir in subdirs:
+        dir_path = os.path.join(input_dir, subdir)
+        for model_info in PRETRAINED_MODEL_INFOS:
+            live_dir = omnipose_threaded.run_omnipose(
+                dir_path,
+                model_info,
+                num_threads=8,
+                channel_order=CHANNEL_ORDER,
+                save_flows=True,
+            )
+            process_masks.process_mask_files(
+                live_dir,
+                CM_PER_PIXEL,
+                PLATE_AREAS.get(PLATE_TYPE),
+                force_save=False,
+                filter_min_size=None,
+            )
+        if DEAD_MODEL_INFO:
+            dead_dir = omnipose_threaded.run_omnipose(
+                dir_path,
+                DEAD_MODEL_INFO[0],
+                num_threads=8,
+                channel_order=CHANNEL_ORDER,
+            )
+            process_masks.process_mask_files(
+                dead_dir,
+                CM_PER_PIXEL,
+                PLATE_AREAS.get(PLATE_TYPE),
+                force_save=False,
+                filter_min_size=None,
+            )
+
+
+def main() -> None:
+    input_dirs = [r"E:\\test"]
+    for input_dir in input_dirs:
         try:
-            print(f"starting {inputDir}")
-            base_dir = r"E:/"
-            output_dir = make_multi_channels.create_merged_directory(inputDir, base_dir)
-
-            max_queue_size=999
-            dir_queue = queue.Queue(maxsize=max_queue_size)
-            lock = threading.Lock()
-
-            consumer_threads = []  # List to keep track of threads
-            for _ in range(1):  # Create and start consumer threads
-                consumer_thread = threading.Thread(target=consumer, args=(output_dir, lock, dir_queue))
-                consumer_thread.start()
-                consumer_threads.append(consumer_thread)
-
-            producer_thread = threading.Thread(target=producer_worker, args=(inputDir, output_dir, dir_queue))
-            producer_thread.start()
-            producer_thread.join()
-
-            for _ in range(len(consumer_threads)):
-                dir_queue.put(None)
-
-            for consumer_thread in consumer_threads:
-                consumer_thread.join()
-
-            for model_info_array in PRETRAINED_MODEL_INFOS:
-                model_name = "_".join(model_info_array[0].split("_")[-8:])
-
-                dead_model_name = "_".join(DEAD_MODEL_INFO[0][0].split("_")[-8:]) if DEAD_MODEL_INFO else None
-                model_output_dir = os.path.join(os.path.join(output_dir,f'{model_name}'))
-
-                # all_data_csv = process_masks.make_all_data_csv(output_dir, model_name)
-
-                # cmd = ["Rscript", r"C:\Users\Tim\clonalisa\src\clonalisa\interaction.R", "--args", all_data_csv] 
-                # subprocess.run(cmd, check=True)
-                # per_well_data_csv_path = measure_growth_rates.calculate_growth_rates_per_well(all_data_csv)
-                # group_columns =  [col for col in pd.read_csv(per_well_data_csv_path).columns if ("Group" in col and not "_Group" in col and not "merged" in col)]
-
-                # import pandas as pd
-                # per_well_data_csv_path = os.path.join(model_output_dir, f'{model_name}_per_well_data.csv')
-                # group_columns =  [col for col in pd.read_csv(os.path.join(model_output_dir, f'{model_name}_per_well_data.csv')).columns if ("Group" in col and not "_Group" in col and not "merged" in col)]
-
-                # for group_col in group_columns:
-                #     measure_growth_rates.plot_over_time(per_well_data_csv_path, group_to_plot=group_col, y_values="exp_rate_cell_density", p_values_col="exp_rate_cell_density", log=True)
-                #     measure_growth_rates.plot_over_time(per_well_data_csv_path, group_to_plot=group_col, y_values="logistic_k_corr_fit_cell_density", p_values_col="logistic_k_corr_fit_cell_density", log=True)
-                #     measure_growth_rates.plot_over_time(per_well_data_csv_path, group_to_plot=group_col, y_values="logistic_k_CV_fit_cell_density", p_values_col="logistic_k_CV_fit_cell_density", log=True)
-                #     measure_growth_rates.plot_over_time(per_well_data_csv_path, group_to_plot=group_col, y_values="cell_density", p_values_col="cell_density", log=True)
-
-        except:
-            print(f'failed {inputDir}')
+            print(f"starting {input_dir}")
+            process_directory(input_dir)
+        except Exception:
+            print(f"failed {input_dir}")
 
 
 if __name__ == "__main__":

--- a/omnipose_threaded.py
+++ b/omnipose_threaded.py
@@ -3,8 +3,10 @@ from itertools import repeat
 import concurrent.futures as cf
 import random
 import time
+import os
+import re
 from pathlib import Path
-from typing import Iterable
+from typing import Iterable, Sequence
 
 import numpy as np
 from skimage import io
@@ -15,6 +17,47 @@ from cellpose_omni import models, core
 import cellpose_omni.io
 
 core.use_gpu()
+
+
+def _extract_well_info(filename: str):
+    match = re.match(r"([A-Z]\d+)_pos(\d+)(Z\d+)?", filename)
+    if match:
+        well_name = match.group(1)
+        position = f"pos{match.group(2)}"
+        return well_name, position
+    return None, None
+
+
+def _collect_image_groups(directory: Path) -> dict[str, list[Path]]:
+    tif_files = [f for f in os.listdir(directory) if f.lower().endswith('.tif') and 'bright' in f.lower()]
+    groups: dict[str, list[Path]] = {}
+    for file in tif_files:
+        well_name, position = _extract_well_info(file)
+        if well_name and position:
+            parts = file.split('_')
+            step = parts[-1].split('.')[0]
+            output_name = f"{well_name}_{position}_merged_{step}"
+            groups.setdefault(output_name, []).append(directory / file)
+    return groups
+
+
+def _load_and_merge(paths: list[Path], order: Sequence[int] | None, crop_size: int = 1992) -> np.ndarray:
+    imgs = []
+    for p in paths:
+        img = io.imread(str(p))
+        if img.shape[0] > crop_size or img.shape[1] > crop_size:
+            center_x, center_y = img.shape[1] // 2, img.shape[0] // 2
+            start_x = center_x - (crop_size // 2)
+            start_y = center_y - (crop_size // 2)
+            img = img[start_y:start_y + crop_size, start_x:start_x + crop_size]
+        imgs.append(img)
+
+    if order:
+        imgs = [imgs[i] for i in order if i < len(imgs)]
+
+    if len(imgs) > 1:
+        return np.stack(imgs, axis=0)
+    return imgs[0]
 
 def _load_model(model_info: tuple[str, float, float]):
     """
@@ -50,11 +93,13 @@ def _load_model(model_info: tuple[str, float, float]):
     )
 
 def _run_on_subset(
-    image_paths: list[Path],
+    groups: list[tuple[str, list[Path]]],
     model_info: tuple[str, float, float],
     out_dir: Path,
-    save_cellProb = True,
-    save_flows = False, save_outlines = False
+    channel_order: Sequence[int] | None,
+    save_cellProb=True,
+    save_flows=False,
+    save_outlines=False,
 ):
     """
     Worker entry-point.
@@ -63,10 +108,11 @@ def _run_on_subset(
     model_filename, flow_thresh, mask_thresh = model_info
     model = _load_model(model_info)
 
-    for img_idx, img_path in enumerate(image_paths):
-        current_image_name = img_path.name # For logging
+    for img_idx, (name, paths) in enumerate(groups):
+        current_image_name = name  # For logging
         try:
-            img_data = [io.imread(str(img_path))] # model.eval expects a list of images
+            img = _load_and_merge(paths, channel_order)
+            img_data = [img]  # model.eval expects a list of images
             masks_list, flows_list, _ = model.eval(
                 img_data, # List containing a single image
                 omni=True,
@@ -84,22 +130,22 @@ def _run_on_subset(
             flows = flows_list[0]
 
             print(f"Worker ({current_image_name}): Saving outputs...")
-            cellpose_omni.io.imwrite(out_dir / (img_path.stem + "_cp_masks.png"), masks)
+            cellpose_omni.io.imwrite(out_dir / f"{name}_cp_masks.png", masks)
             if save_cellProb and flows is not None and len(flows) > 2 and flows[2] is not None:
                 cell_prob_map = flows[2]
                 scaled_prob_map = np.clip(cell_prob_map * 21.25, 0, 255).astype(np.uint8)
-                cellpose_omni.io.imwrite(out_dir / (img_path.stem + "_cellProb.png"), scaled_prob_map)
+                cellpose_omni.io.imwrite(out_dir / f"{name}_cellProb.png", scaled_prob_map)
             else:
-                print(f"Warning: Could not extract cell_prob_map for {img_path.name}")
+                print(f"Warning: Could not extract cell_prob_map for {name}")
             if save_flows and flows is not None and len(flows) > 2 and flows[0] is not None:
-                cellpose_omni.io.imwrite(out_dir / (img_path.stem + "_flows.png"), flows[0].astype(np.uint8))
+                cellpose_omni.io.imwrite(out_dir / f"{name}_flows.png", flows[0].astype(np.uint8))
             else:
-                print(f"Warning: Could not extract flows_rgb_map for {img_path.name}")
+                print(f"Warning: Could not extract flows_rgb_map for {name}")
 
-            print(f"✓ {img_path.name}")
+            print(f"✓ {name}")
 
         except Exception as e:
-            print(f"✗ {img_path.name}  (Error: {e})")
+            print(f"✗ {name}  (Error: {e})")
             import traceback
             traceback.print_exc() # Print full traceback for errors in worker
 
@@ -109,6 +155,7 @@ def run_omnipose(
     directory: str | Path,
     model_info: tuple[str, float, float],
     *,
+    channel_order: Sequence[int] | None = None,
     save_cellProb: bool = True,
     save_flows: bool = False,
     save_outlines: bool = False,
@@ -141,50 +188,46 @@ def run_omnipose(
     out_dir.mkdir(parents=True, exist_ok=True)
 
     masks_done = {p.stem.replace("_cp_masks", "") for p in out_dir.glob("*_cp_masks.png")}
-    imgs_iterable: Iterable[Path] = (
-        p
-        for p in directory.glob("*.tif*") # Handles .tif and .tiff
-        if all(s not in p.name for s in ("masks", "dP.tif", "outlines.tif", "flows.tif", "Wells", "cellProb"))
-        and p.stem not in masks_done
-    )
-    all_imgs = list(imgs_iterable) # Make it a list to shuffle and chunk
-    
-    if not all_imgs:
+    groups_dict = _collect_image_groups(directory)
+    all_groups = [(name, paths) for name, paths in groups_dict.items() if name not in masks_done]
+
+    if not all_groups:
         print("No new images to process.")
         return out_dir
-        
-    random.shuffle(all_imgs) # Shuffle before chunking
 
-    num_workers = min(num_threads, len(all_imgs))
-    if num_workers == 0: # Should not happen if all_imgs is not empty, but good practice
+    random.shuffle(all_groups)
+
+    num_workers = min(num_threads, len(all_groups))
+    if num_workers == 0:
         print("No workers to spawn (num_threads or image count is 0).")
         return out_dir
-        
-    # Split into roughly equal chunks for each worker
-    chunks: list[list[Path]] = [[] for _ in range(num_workers)]
-    for i, img_path in enumerate(all_imgs):
-        chunks[i % num_workers].append(img_path)
-    
-    # Filter out empty chunks if len(all_imgs) < num_threads
+
+    chunks: list[list[tuple[str, list[Path]]]] = [[] for _ in range(num_workers)]
+    for i, grp in enumerate(all_groups):
+        chunks[i % num_workers].append(grp)
+
     chunks = [chunk for chunk in chunks if chunk]
-    actual_num_workers = len(chunks) # This will be the actual number of processes
+    actual_num_workers = len(chunks)
 
     if actual_num_workers == 0:
-        print("No images assigned to any worker.") # Should be caught by 'if not all_imgs'
+        print("No images assigned to any worker.")  # Should be caught by 'if not all_groups'
         return out_dir
 
-    print(f"Processing {len(all_imgs)} images using {actual_num_workers} worker(s).")
+    print(f"Processing {len(all_groups)} images using {actual_num_workers} worker(s).")
     
     with cf.ProcessPoolExecutor(max_workers=actual_num_workers) as pool:
-        results = list(pool.map(
-            _run_on_subset,
-            chunks,                        # iterable ➊ – images for each worker
-            repeat(model_info),            # broadcast constants ⤵
-            repeat(out_dir),
-            repeat(save_cellProb),
-            repeat(save_flows),
-            repeat(save_outlines)
-        ))
+        results = list(
+            pool.map(
+                _run_on_subset,
+                chunks,
+                repeat(model_info),
+                repeat(out_dir),
+                repeat(channel_order),
+                repeat(save_cellProb),
+                repeat(save_flows),
+                repeat(save_outlines),
+            )
+        )
 
 
     return out_dir


### PR DESCRIPTION
## Summary
- consolidate multi-channel merging helpers
- build multi-channel images just before running Omnipose
- streamline `run_omnipose` with in-memory image stacking
- remove producer/consumer threading and simplify pipeline

## Testing
- `python -m py_compile $(git ls-files '*.py')`