### PR TITLE
Add step regex and improve time source

### DIFF
--- a/clonalisa_GUI.py
+++ b/clonalisa_GUI.py
@@ -8,8 +8,11 @@ import process_masks
 
 from PySide6.QtWidgets import (
     QApplication, QWidget, QFileDialog, QVBoxLayout, QHBoxLayout,
-    QLabel, QLineEdit, QPushButton, QCheckBox, QTextEdit
+    QLabel, QLineEdit, QPushButton, QCheckBox, QTextEdit, QComboBox,
+    QDialog, QFormLayout, QDialogButtonBox, QRadioButton, QButtonGroup
 )
+
+from config_utils import load_config, save_config
 
 # Constants similar to simple_omnipose_gui
 MAX_WORKERS = os.cpu_count() // 2
@@ -33,12 +36,48 @@ else:
 CM_PER_PIXEL = CM_PER_MICRON * MICRONS_PER_PIXEL
 
 
+class ConfigDialog(QDialog):
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self.setWindowTitle("Configuration")
+        self.cfg = load_config()
+
+        layout = QFormLayout(self)
+        self.regex_file = QLineEdit(self.cfg.get('regex', {}).get('file', ''))
+        self.regex_time = QLineEdit(self.cfg.get('regex', {}).get('time_from_folder', ''))
+
+        layout.addRow("Filename regex", self.regex_file)
+        layout.addRow("Time regex", self.regex_time)
+
+        self.time_combo = QComboBox()
+        self.time_combo.addItem("folder")
+        self.time_combo.addItem("date_created")
+        current = 1 if self.cfg.get('time_source', 'folder') == 'date_created' else 0
+        self.time_combo.setCurrentIndex(current)
+        layout.addRow("Time source", self.time_combo)
+
+        btns = QDialogButtonBox(QDialogButtonBox.Ok | QDialogButtonBox.Cancel)
+        btns.accepted.connect(self.accept)
+        btns.rejected.connect(self.reject)
+        layout.addRow(btns)
+
+    def save(self):
+        self.cfg['regex'] = {
+            'file': self.regex_file.text(),
+            'time_from_folder': self.regex_time.text(),
+        }
+        self.cfg['time_source'] = self.time_combo.currentText()
+        save_config(self.cfg)
+
+
 class clonalisaGUI(QWidget):
     def __init__(self) -> None:
         super().__init__()
         self.setWindowTitle("ClonaLiSA")
         self.resize(600, 400)
+        self.cfg = load_config()
         self._setup_ui()
+        self._model_selected(0)
 
     def _setup_ui(self) -> None:
         layout = QVBoxLayout(self)
@@ -54,16 +93,29 @@ class clonalisaGUI(QWidget):
         inp_layout.addWidget(browse_inp)
         layout.addLayout(inp_layout)
 
-        # Model file
+        # Model selection
         mod_layout = QHBoxLayout()
-        mod_label = QLabel("Model file:")
-        self.mod_edit = QLineEdit()
+        mod_label = QLabel("Model:")
+        self.model_combo = QComboBox()
+        self.model_combo.setEditable(True)
+        for entry in self.cfg.get('model_history', []):
+            self.model_combo.addItem(entry['path'])
+        self.model_combo.currentIndexChanged.connect(self._model_selected)
         browse_mod = QPushButton("Browse")
         browse_mod.clicked.connect(self._browse_model)
         mod_layout.addWidget(mod_label)
-        mod_layout.addWidget(self.mod_edit)
+        mod_layout.addWidget(self.model_combo)
         mod_layout.addWidget(browse_mod)
         layout.addLayout(mod_layout)
+
+        thr_layout = QHBoxLayout()
+        self.flow_edit = QLineEdit()
+        self.mask_edit = QLineEdit()
+        thr_layout.addWidget(QLabel("Flow thr:"))
+        thr_layout.addWidget(self.flow_edit)
+        thr_layout.addWidget(QLabel("Mask thr:"))
+        thr_layout.addWidget(self.mask_edit)
+        layout.addLayout(thr_layout)
 
         # Filtering keyword
         filt_layout = QHBoxLayout()
@@ -96,6 +148,10 @@ class clonalisaGUI(QWidget):
         run_btn.clicked.connect(self._run_pipeline)
         layout.addWidget(run_btn)
 
+        cfg_btn = QPushButton("Config")
+        cfg_btn.clicked.connect(self._open_config)
+        layout.addWidget(cfg_btn)
+
         # --- Run R section ---
         csv_layout = QHBoxLayout()
         csv_label = QLabel("all_data_csv:")
@@ -124,7 +180,8 @@ class clonalisaGUI(QWidget):
     def _browse_model(self) -> None:
         path, _ = QFileDialog.getOpenFileName(self, "Select model", "omnipose_models")
         if path:
-            self.mod_edit.setText(path)
+            self.model_combo.setEditText(path)
+            self.model_combo.setCurrentIndex(-1)
 
     def _browse_csv(self) -> None:
         path, _ = QFileDialog.getOpenFileName(self, "Select all_data_csv", filter="CSV Files (*.csv)")
@@ -135,9 +192,35 @@ class clonalisaGUI(QWidget):
         self.log.append(text)
         self.log.ensureCursorVisible()
 
+    def _model_selected(self, idx: int) -> None:
+        if idx < 0 or idx >= len(self.cfg.get('model_history', [])):
+            return
+        entry = self.cfg['model_history'][idx]
+        self.model_combo.setEditText(entry['path'])
+        self.flow_edit.setText(str(entry.get('flow_threshold', '')))
+        self.mask_edit.setText(str(entry.get('mask_threshold', '')))
+        if entry.get('z_indices'):
+            self.z_edit.setText(','.join(str(z) for z in entry['z_indices']))
+
+    def _refresh_model_combo(self) -> None:
+        current = self.model_combo.currentText()
+        self.model_combo.blockSignals(True)
+        self.model_combo.clear()
+        for entry in self.cfg.get('model_history', []):
+            self.model_combo.addItem(entry['path'])
+        self.model_combo.blockSignals(False)
+        if current:
+            self.model_combo.setEditText(current)
+
+    def _open_config(self) -> None:
+        dlg = ConfigDialog(self)
+        if dlg.exec() == QDialog.Accepted:
+            dlg.save()
+            self.cfg = load_config()
+            self._refresh_model_combo()
     def _run_pipeline(self) -> None:
         input_dir = self.inp_edit.text()
-        model_file = self.mod_edit.text()
+        model_file = self.model_combo.currentText()
         if not Path(input_dir).is_dir():
             self._append_log("Invalid input directory")
             return
@@ -149,8 +232,11 @@ class clonalisaGUI(QWidget):
         z_text = self.z_edit.text().strip()
         z_indices = [int(i) for i in z_text.split(',') if i.strip().isdigit()] if z_text else None
 
+        flow_thr = float(self.flow_edit.text() or 0)
+        mask_thr = float(self.mask_edit.text() or 0)
+
         self._append_log("Running Omnipose...")
-        model_info = (model_file, 0.4, 0)
+        model_info = (model_file, flow_thr, mask_thr)
         for sub in os.listdir(input_dir):
             sub_path = os.path.join(input_dir, sub)
             if not os.path.isdir(sub_path) or "epoch" in sub:
@@ -177,6 +263,17 @@ class clonalisaGUI(QWidget):
             self.csv_edit.setText(all_csv)
             self._append_log(f"Created {all_csv}")
         self._append_log("Finished Omnipose pipeline")
+
+        entry = {
+            'path': model_file,
+            'flow_threshold': flow_thr,
+            'mask_threshold': mask_thr,
+            'z_indices': z_indices or [],
+        }
+        existing = [e for e in self.cfg.get('model_history', []) if e['path'] != model_file]
+        self.cfg['model_history'] = [entry] + existing
+        save_config(self.cfg)
+        self._refresh_model_combo()
 
     def _run_rscript(self) -> None:
         csv_path = self.csv_edit.text()

--- a/clonalisa_config.json
+++ b/clonalisa_config.json
@@ -1,0 +1,15 @@
+{
+  "regex": {
+    "file": "(?P<well>[A-Za-z]+\\d+)_pos(?P<position>\\d+)(?:_(?P<channel>[^_]+))?(?:_Z(?P<z_index>\\d+))?(?:_s(?P<step>\\d+))?",
+    "time_from_folder": ".*_(?P<date>\\d{8})_(?P<time>\\d{6})$"
+  },
+  "time_source": "folder",
+  "model_history": [
+    {
+      "path": "omnipose_models/10x_NPC_nclasses_2_nchan_3_dim_2_2024_03_29_02_03_10.875324_epoch_960",
+      "flow_threshold": 0.4,
+      "mask_threshold": 0.0,
+      "z_indices": [1, 2, 0]
+    }
+  ]
+}

--- a/config_utils.py
+++ b/config_utils.py
@@ -1,0 +1,92 @@
+import json
+import re
+import os
+from pathlib import Path
+from datetime import datetime
+
+CONFIG_PATH = Path(__file__).resolve().parent / 'clonalisa_config.json'
+
+DEFAULT_CONFIG = {
+    "regex": {
+        "file": r"(?P<well>[A-Za-z]+\d+)_pos(?P<position>\d+)(?:_(?P<channel>[^_]+))?(?:_Z(?P<z_index>\d+))?(?:_s(?P<step>\d+))?",
+        "time_from_folder": r".*_(?P<date>\d{8})_(?P<time>\d{6})$",
+    },
+    "time_source": "folder",
+    "model_history": [
+        {
+            "path": str(Path('omnipose_models/10x_NPC_nclasses_2_nchan_3_dim_2_2024_03_29_02_03_10.875324_epoch_960')),
+            "flow_threshold": 0.4,
+            "mask_threshold": 0.0,
+            "z_indices": [1, 2, 0],
+        }
+    ],
+}
+
+
+def load_config():
+    if CONFIG_PATH.exists():
+        try:
+            with open(CONFIG_PATH, 'r') as f:
+                return json.load(f)
+        except Exception:
+            pass
+    return DEFAULT_CONFIG.copy()
+
+
+def save_config(cfg):
+    with open(CONFIG_PATH, 'w') as f:
+        json.dump(cfg, f, indent=2)
+
+
+def parse_filename(filename, cfg=None):
+    if cfg is None:
+        cfg = load_config()
+    pattern = cfg.get('regex', {}).get('file', DEFAULT_CONFIG['regex']['file'])
+    m = re.match(pattern, Path(filename).stem)
+    if not m:
+        return None, None, None, None, None
+    groups = m.groupdict()
+    well = groups.get('well')
+    position = groups.get('position')
+    channel = groups.get('channel')
+    z_index = groups.get('z_index')
+    step = groups.get('step')
+    if z_index is not None:
+        try:
+            z_index = int(z_index)
+        except ValueError:
+            z_index = None
+    if step is not None:
+        try:
+            step = int(step)
+        except ValueError:
+            step = None
+    return well, position, channel, z_index, step
+
+
+def extract_time_from_folder(folder_name, cfg=None):
+    if cfg is None:
+        cfg = load_config()
+    pattern = cfg.get('regex', {}).get('time_from_folder', DEFAULT_CONFIG['regex']['time_from_folder'])
+    m = re.match(pattern, folder_name)
+    if not m:
+        return None
+    gd = m.groupdict()
+    if 'date' in gd and 'time' in gd:
+        dt_str = f"{gd['date']} {gd['time']}"
+        return datetime.strptime(dt_str, '%Y%m%d %H%M%S')
+    return None
+
+
+def get_image_time(image_path, cfg=None):
+    if cfg is None:
+        cfg = load_config()
+    source = cfg.get('time_source', 'folder')
+    if source == 'date_created':
+        try:
+            ts = Path(image_path).stat().st_ctime
+            return datetime.fromtimestamp(ts)
+        except Exception:
+            return None
+    # fallback to folder name
+    return extract_time_from_folder(Path(image_path).parent.name, cfg)

--- a/omnipose_threaded.py
+++ b/omnipose_threaded.py
@@ -4,7 +4,7 @@ import concurrent.futures as cf
 import random
 import time
 import os
-import re
+import json
 from pathlib import Path
 from typing import Iterable, Sequence
 
@@ -16,16 +16,15 @@ from importlib.resources import files
 from cellpose_omni import models, core
 import cellpose_omni.io
 from process_masks import color_and_outline_cells_per_channel
+from config_utils import parse_filename
 
 core.use_gpu()
 
 
 def _extract_well_info(filename: str):
-    match = re.match(r"([A-Z]\d+)_pos(\d+)(Z\d+)?", filename)
-    if match:
-        well_name = match.group(1)
-        position = f"pos{match.group(2)}"
-        return well_name, position
+    well, position, _, _, _ = parse_filename(filename)
+    if well and position:
+        return well, f"pos{position}"
     return None, None
 
 
@@ -54,19 +53,15 @@ def _collect_image_groups(
 
     groups: dict[str, list[Path]] = {}
     for file in tif_files:
-        well_name, position = _extract_well_info(file)
+        well_name, position, _, _, step = parse_filename(file)
         if well_name and position:
-            parts = file.split("_")
-            step = parts[-1].split(".")[0]
+            step = step if step is not None else 0
             output_name = f"{well_name}_{position}_merged_{step}"
             groups.setdefault(output_name, []).append(directory / file)
 
     for name, paths in list(groups.items()):
-        # sort by Z index if present
         paths.sort(
-            key=lambda p: int(re.search(r"Z(\d+)", p.stem).group(1))
-            if re.search(r"Z(\d+)", p.stem)
-            else 0
+            key=lambda p: (parse_filename(p.name)[3] or 0)
         )
         if z_indices is not None:
             groups[name] = [p for idx, p in enumerate(paths) if idx in z_indices]
@@ -210,6 +205,8 @@ def run_omnipose(
 
     masks_done = {p.stem.replace("_cp_masks", "") for p in out_dir.glob("*_cp_masks.png")}
     groups_dict = _collect_image_groups(directory, keyword=filter_keyword, z_indices=z_indices)
+    with open(out_dir / "source_images.json", "w") as f:
+        json.dump({k: [str(p) for p in v] for k, v in groups_dict.items()}, f, indent=2)
     all_groups = [(name, paths) for name, paths in groups_dict.items() if name not in masks_done]
 
     if not all_groups:


### PR DESCRIPTION
## Summary
- make filename regex capture step
- store original image paths in `source_images.json`
- use mapping when computing creation times
- change model selector to editable dropdown with browse button
- use dropdown for time source in config

## Testing
- `python -m py_compile config_utils.py clonalisa_GUI.py omnipose_threaded.py process_masks.py`

------
https://chatgpt.com/codex/tasks/task_e_683e0e90abfc83219e3ef632360a0ef2