### PR TITLE
Refactor time handling and add plate grouping GUI

### DIFF
--- a/clonalisa_GUI.py
+++ b/clonalisa_GUI.py
@@ -1,46 +1,75 @@
 from __future__ import annotations
-import os
-import subprocess
+import os, sys, subprocess
 from pathlib import Path
 
-import omnipose_threaded
-import process_masks
+import omnipose_threaded, process_masks
+import pandas as pd
 
 from PySide6.QtWidgets import (
-    QApplication, QWidget, QFileDialog, QVBoxLayout, QHBoxLayout,
-    QLabel, QLineEdit, QPushButton, QCheckBox, QTextEdit, QComboBox,
-    QDialog, QFormLayout, QDialogButtonBox, QRadioButton, QButtonGroup,
-    QTableWidget, QTableWidgetItem, QInputDialog
+    QApplication, QWidget, QFileDialog, QTableWidget, QTableWidgetItem,
+    QInputDialog, QDialog, QFormLayout, QLineEdit, QDialogButtonBox
 )
 from PySide6.QtGui import QColor
 from PySide6.QtCore import Qt
+from PySide6.QtUiTools import QUiLoader
 
 from config_utils import load_config, save_config, parse_filename
-import pandas as pd
 
-# Constants similar to simple_omnipose_gui
-MAX_WORKERS = os.cpu_count() // 2
-PLATE_TYPE = "96W"
+from PySide6.QtUiTools import QUiLoader
+from PySide6.QtCore    import QFile, QObject
+
+from PySide6.QtWidgets import QVBoxLayout
+from PySide6.QtWidgets import QHeaderView
+
+from PySide6.QtGui import QPalette, QColor
+from PySide6.QtWidgets import QStyleFactory
+
+from colorsys import hsv_to_rgb
+
+def enable_dark_palette(app):
+    """Switch to Fusion style + dark palette."""
+    app.setStyle(QStyleFactory.create("Fusion"))
+    pal = QPalette()
+
+    # basic tones
+    dark   = QColor(45, 45, 45)
+    mid    = QColor(60, 60, 60)
+    light  = QColor(90, 90, 90)
+    text   = QColor(220, 220, 220)
+    accent = QColor(53, 132, 228)  # links / highlights
+
+    pal.setColor(QPalette.Window,        dark)
+    pal.setColor(QPalette.WindowText,    text)
+    pal.setColor(QPalette.Base,          mid)
+    pal.setColor(QPalette.AlternateBase, dark)
+    pal.setColor(QPalette.ToolTipBase,   text)
+    pal.setColor(QPalette.ToolTipText,   text)
+    pal.setColor(QPalette.Text,          text)
+    pal.setColor(QPalette.Button,        mid)
+    pal.setColor(QPalette.ButtonText,    text)
+    pal.setColor(QPalette.Link,          accent)
+    pal.setColor(QPalette.Highlight,     accent)
+    pal.setColor(QPalette.HighlightedText, QColor("white"))
+
+    app.setPalette(pal)
+
+
+# -------- constants ----------------------------------------------------------
+MAX_WORKERS   = os.cpu_count() // 2
+PLATE_TYPE    = "96W"
 MAGNIFICATION = "10x"
-CYTATION = True
+CYTATION      = True
 
-PLATE_AREAS = {"6W": 9.6, "12W": 3.8, "24W": 2, "48W": 1.1, "96W": 0.32}
-CM_PER_MICRON = 1 / 10000
-if CYTATION:
-    MICRONS_PER_PIXEL = 1389 / 1992 if MAGNIFICATION == "10x" else 694 / 1992
-    IMAGE_AREA_CM = 1992 * 1992 * MICRONS_PER_PIXEL**2 * CM_PER_MICRON**2
-else:
-    if MAGNIFICATION == "10x":
-        MICRONS_PER_PIXEL = 0.61922571983322461
-        IMAGE_AREA_CM = 0.0120619953
-    else:
-        MICRONS_PER_PIXEL = 1.5188172690164046
-        IMAGE_AREA_CM = 0.0725658405
-
-CM_PER_PIXEL = CM_PER_MICRON * MICRONS_PER_PIXEL
+PLATE_AREAS        = {"6W": 9.6, "12W": 3.8, "24W": 2, "48W": 1.1, "96W": 0.32}
+CM_PER_MICRON      = 1 / 10000
+MICRONS_PER_PIXEL  = (1389 / 1992 if MAGNIFICATION == "10x" else 694 / 1992) if CYTATION \
+                     else (0.61922571983322461 if MAGNIFICATION == "10x" else 1.5188172690164046)
+CM_PER_PIXEL       = CM_PER_MICRON * MICRONS_PER_PIXEL
+# -----------------------------------------------------------------------------
 
 
 class ConfigDialog(QDialog):
+    """Simple dialog for editing regex settings."""
     def __init__(self, parent=None):
         super().__init__(parent)
         self.setWindowTitle("Configuration")
@@ -49,10 +78,8 @@ class ConfigDialog(QDialog):
         layout = QFormLayout(self)
         self.regex_file = QLineEdit(self.cfg.get('regex', {}).get('file', ''))
         self.regex_time = QLineEdit(self.cfg.get('regex', {}).get('time_from_folder', ''))
-
         layout.addRow("Filename regex", self.regex_file)
-        layout.addRow("Time regex", self.regex_time)
-
+        layout.addRow("Time regex",      self.regex_time)
 
         btns = QDialogButtonBox(QDialogButtonBox.Ok | QDialogButtonBox.Cancel)
         btns.accepted.connect(self.accept)
@@ -66,207 +93,153 @@ class ConfigDialog(QDialog):
         }
         save_config(self.cfg)
 
+def load_ui(path: str | os.PathLike, container: QWidget):
+    loader = QUiLoader()
 
-class clonalisaGUI(QWidget):
-    def __init__(self) -> None:
+    # ---- load the form WITHOUT passing the container --------------
+    ui_file = QFile(str(path))
+    ui_file.open(QFile.ReadOnly)
+    form = loader.load(ui_file)          # a QWidget with your splitter etc.
+    ui_file.close()
+
+    # ---- give the window a layout and shove the form in -----------
+    lay = QVBoxLayout(container)
+    lay.setContentsMargins(0, 0, 0, 0)
+    lay.addWidget(form)
+
+    # ---- expose children as attributes (optional) -----------------
+    for obj in form.findChildren(QObject):
+        if obj.objectName():
+            setattr(container, obj.objectName(), obj)
+                    
+class ClonaLiSAGUI(QWidget):
+    """Main window – UI is loaded from clonalisa.ui."""
+    def __init__(self):
         super().__init__()
-        self.setWindowTitle("ClonaLiSA")
-        self.resize(600, 400)
-        self.cfg = load_config()
-        self.plate_wells: dict[str, set[str]] = {}
-        self.group_data: dict[str, dict[str, dict[str, str]]] = {}
-        self._setup_ui()
-        self._model_selected(0)
 
-    def _setup_ui(self) -> None:
-        layout = QVBoxLayout(self)
+        # ----- load the .ui file ------------------------------------------------
+        ui_path = Path(__file__).with_name("clonalisa_ui.ui")
+        load_ui(ui_path, self)  
+        # -----------------------------------------------------------------------
 
-        # Input directory
-        inp_layout = QHBoxLayout()
-        inp_label = QLabel("Input directory:")
-        self.inp_edit = QLineEdit()
-        browse_inp = QPushButton("Browse")
-        browse_inp.clicked.connect(self._browse_input)
-        inp_layout.addWidget(inp_label)
-        inp_layout.addWidget(self.inp_edit)
-        inp_layout.addWidget(browse_inp)
-        layout.addLayout(inp_layout)
+        # internal state --------------------------------------------------------
+        self.cfg         = load_config()
+        self.plate_wells = {}   # { plate: {A1, B3, ...} }
+        self.group_data  = {}   # { plate: {group: {well: value}} }
+        # -----------------------------------------------------------------------
 
-        plate_layout = QHBoxLayout()
-        plate_layout.addWidget(QLabel("Plate:"))
-        self.plate_combo = QComboBox()
-        self.plate_combo.currentIndexChanged.connect(self._plate_selected)
-        plate_layout.addWidget(self.plate_combo)
-        self.view_combo = QComboBox()
-        self.view_combo.addItem("Imaged Wells")
-        self.view_combo.currentIndexChanged.connect(self._update_grid)
-        plate_layout.addWidget(self.view_combo)
-        layout.addLayout(plate_layout)
-
-        self.table = QTableWidget(8, 12)
+        # ----- post-load tweaks Designer can’t express -----------------------
+        self.table: QTableWidget
+        self.table.setRowCount(8)
+        self.table.setColumnCount(12)
         self.table.setSelectionMode(QTableWidget.ExtendedSelection)
         self.table.setEditTriggers(QTableWidget.NoEditTriggers)
-        self.table.setHorizontalHeaderLabels([str(i+1) for i in range(12)])
-        self.table.setVerticalHeaderLabels([chr(ord('A')+i) for i in range(8)])
-        layout.addWidget(self.table)
+        self.table.setHorizontalHeaderLabels([str(i + 1) for i in range(12)])
+        self.table.setVerticalHeaderLabels([chr(ord('A') + i) for i in range(8)])
+        self.table.horizontalHeader().setSectionResizeMode(QHeaderView.Stretch)
+        self.table.verticalHeader().setSectionResizeMode(QHeaderView.Stretch)
 
-        group_layout = QHBoxLayout()
-        self.group_combo = QComboBox()
-        group_layout.addWidget(self.group_combo)
-        new_group = QPushButton("New Group")
-        new_group.clicked.connect(self._new_group)
-        group_layout.addWidget(new_group)
-        self.value_edit = QLineEdit()
-        self.value_edit.setPlaceholderText("Value")
-        group_layout.addWidget(self.value_edit)
-        apply_btn = QPushButton("Apply")
-        apply_btn.clicked.connect(self._apply_group)
-        group_layout.addWidget(apply_btn)
-        save_btn = QPushButton("Save Groups")
-        save_btn.clicked.connect(self._save_group_map)
-        group_layout.addWidget(save_btn)
-        layout.addLayout(group_layout)
+        self.value_colors = {}          # { "treatmentA": QColor, ... }
+        self._next_hue    = 0           # rolling hue pointer (0-359)
 
-        # Model selection
-        mod_layout = QHBoxLayout()
-        mod_label = QLabel("Model:")
-        self.model_combo = QComboBox()
-        self.model_combo.setEditable(True)
-        for entry in self.cfg.get('model_history', []):
-            self.model_combo.addItem(entry['path'])
+
+        # ---------------------------------------------------------------------
+
+        # ---------- connect signals ------------------------------------------
+        self.btnBrowseInput.clicked.connect(self._browse_input)
+        self.btnBrowseModel.clicked.connect(self._browse_model)
+        self.btnBrowseCSV.clicked.connect(self._browse_csv)
+
+        self.plate_combo.currentIndexChanged.connect(self._plate_selected)
+        self.view_combo.currentIndexChanged.connect(self._update_grid)
         self.model_combo.currentIndexChanged.connect(self._model_selected)
-        browse_mod = QPushButton("Browse")
-        browse_mod.clicked.connect(self._browse_model)
-        mod_layout.addWidget(mod_label)
-        mod_layout.addWidget(self.model_combo)
-        mod_layout.addWidget(browse_mod)
-        layout.addLayout(mod_layout)
 
-        thr_layout = QHBoxLayout()
-        self.flow_edit = QLineEdit()
-        self.mask_edit = QLineEdit()
-        thr_layout.addWidget(QLabel("Flow thr:"))
-        thr_layout.addWidget(self.flow_edit)
-        thr_layout.addWidget(QLabel("Mask thr:"))
-        thr_layout.addWidget(self.mask_edit)
-        layout.addLayout(thr_layout)
+        self.btnNewGroup.clicked.connect(self._new_group)
+        self.btnApplyGroup.clicked.connect(self._apply_group)
+        self.btnSaveGroups.clicked.connect(self._save_group_map)
 
-        # Filtering keyword
-        filt_layout = QHBoxLayout()
-        filt_label = QLabel("Filter keyword:")
-        self.filt_edit = QLineEdit("bright")
-        filt_layout.addWidget(filt_label)
-        filt_layout.addWidget(self.filt_edit)
-        layout.addLayout(filt_layout)
+        self.btnRunOmnipose.clicked.connect(self._run_pipeline)
+        self.btnRunR.clicked.connect(self._run_rscript)
+        self.btnConfig.clicked.connect(self._open_config)
+        # ---------------------------------------------------------------------
 
-        # Z indices
-        z_layout = QHBoxLayout()
-        z_label = QLabel("Z indices (comma separated):")
-        self.z_edit = QLineEdit("0,1,2")
-        z_layout.addWidget(z_label)
-        z_layout.addWidget(self.z_edit)
-        layout.addLayout(z_layout)
+        # internal state, preload model history …
+        self.cfg         = load_config()
+        self.plate_wells = {}
+        self.group_data  = {}
+        self._model_selected(0)
 
-        # Options
-        opt_layout = QHBoxLayout()
-        self.cb_flows = QCheckBox("Save flows")
-        self.cb_cellprob = QCheckBox("Save cell prob")
-        self.cb_outlines = QCheckBox("Save outlines")
-        self.cb_outlines.setChecked(True)
-        opt_layout.addWidget(self.cb_flows)
-        opt_layout.addWidget(self.cb_cellprob)
-        opt_layout.addWidget(self.cb_outlines)
-        layout.addLayout(opt_layout)
+    # ==========================================================================
+    # ---------------------------- helper slots --------------------------------
+    # ==========================================================================
 
-        run_btn = QPushButton("Run Omnipose")
-        run_btn.clicked.connect(self._run_pipeline)
-        layout.addWidget(run_btn)
+    def _color_for_value(self, val: str) -> QColor:
+        """Assign (or retrieve) a pastel color for a specific value string."""
+        if val not in self.value_colors:
+            # step through hues 40° apart for variety
+            h = (self._next_hue % 360) / 360.0
+            self._next_hue += 40
+            r, g, b = hsv_to_rgb(h, 0.45, 0.85)  # pastel-ish
+            self.value_colors[val] = QColor(int(r*255), int(g*255), int(b*255))
+        return self.value_colors[val]
 
-        cfg_btn = QPushButton("Config")
-        cfg_btn.clicked.connect(self._open_config)
-        layout.addWidget(cfg_btn)
+    # -- generic --------------------------------------------------------------
+    def _append_log(self, text: str):
+        self.log.append(text)
+        self.log.ensureCursorVisible()
 
-        # --- Run R section ---
-        csv_layout = QHBoxLayout()
-        csv_label = QLabel("all_data_csv:")
-        self.csv_edit = QLineEdit()
-        browse_csv = QPushButton("Browse")
-        browse_csv.clicked.connect(self._browse_csv)
-        csv_layout.addWidget(csv_label)
-        csv_layout.addWidget(self.csv_edit)
-        csv_layout.addWidget(browse_csv)
-        layout.addLayout(csv_layout)
-
-        r_btn = QPushButton("Run R Analysis")
-        r_btn.clicked.connect(self._run_rscript)
-        layout.addWidget(r_btn)
-
-        self.log = QTextEdit()
-        self.log.setReadOnly(True)
-        layout.addWidget(self.log)
-
-    # ----- helpers -----
-    def _browse_input(self) -> None:
+    # -- browse helpers --------------------------------------------------------
+    def _browse_input(self):
         path = QFileDialog.getExistingDirectory(self, "Select folder")
         if path:
             self.inp_edit.setText(path)
             self._load_plates(path)
 
-    def _browse_model(self) -> None:
+    def _browse_model(self):
         path, _ = QFileDialog.getOpenFileName(self, "Select model", "omnipose_models")
-        if path:
-            if path not in [self.model_combo.itemText(i) for i in range(self.model_combo.count())]:
-                self.model_combo.addItem(path)
-            self.model_combo.setCurrentText(path)
-            self.model_combo.setEditText(path)
+        if path and path not in [self.model_combo.itemText(i) for i in range(self.model_combo.count())]:
+            self.model_combo.addItem(path)
+        self.model_combo.setCurrentText(path)
 
-    def _browse_csv(self) -> None:
+    def _browse_csv(self):
         path, _ = QFileDialog.getOpenFileName(self, "Select all_data_csv", filter="CSV Files (*.csv)")
         if path:
             self.csv_edit.setText(path)
 
-    def _append_log(self, text: str) -> None:
-        self.log.append(text)
-        self.log.ensureCursorVisible()
+    # -- model-history ---------------------------------------------------------
+    def _model_selected(self, idx: int):
+        hist = self.cfg.get('model_history', [])
+        if 0 <= idx < len(hist):
+            entry = hist[idx]
+            self.model_combo.setEditText(entry['path'])
+            self.flow_edit.setText(str(entry.get('flow_threshold', '')))
+            self.mask_edit.setText(str(entry.get('mask_threshold', '')))
+            if entry.get('z_indices'):
+                self.z_edit.setText(','.join(map(str, entry['z_indices'])))
 
-    def _model_selected(self, idx: int) -> None:
-        if idx < 0 or idx >= len(self.cfg.get('model_history', [])):
-            return
-        entry = self.cfg['model_history'][idx]
-        self.model_combo.setEditText(entry['path'])
-        self.flow_edit.setText(str(entry.get('flow_threshold', '')))
-        self.mask_edit.setText(str(entry.get('mask_threshold', '')))
-        if entry.get('z_indices'):
-            self.z_edit.setText(','.join(str(z) for z in entry['z_indices']))
-
-    def _refresh_model_combo(self) -> None:
+    def _refresh_model_combo(self):
         current = self.model_combo.currentText()
         self.model_combo.blockSignals(True)
         self.model_combo.clear()
         for entry in self.cfg.get('model_history', []):
             self.model_combo.addItem(entry['path'])
         self.model_combo.blockSignals(False)
-        if current:
-            self.model_combo.setCurrentText(current)
+        self.model_combo.setCurrentText(current)
 
-    # ----- plate/group helpers -----
-    def _load_plates(self, folder: str) -> None:
+    # -- plate / well grid -----------------------------------------------------
+    def _load_plates(self, folder: str):
         self.plate_combo.clear()
         self.view_combo.clear()
         self.view_combo.addItem("Imaged Wells")
         self.table.clearContents()
         self.plate_wells.clear()
         self.group_data.clear()
-        plates = set()
-        for sub in os.listdir(folder):
-            if os.path.isdir(os.path.join(folder, sub)):
-                plates.add(sub.split('_')[0])
-        for p in sorted(plates):
-            self.plate_combo.addItem(p)
 
-    def _plate_selected(self, idx: int) -> None:
-        if idx < 0:
-            return
+        plates = {sub.split('_')[0] for sub in os.listdir(folder)
+                  if os.path.isdir(os.path.join(folder, sub))}
+        self.plate_combo.addItems(sorted(plates))
+
+    def _plate_selected(self, _):
         plate = self.plate_combo.currentText()
         if not plate:
             return
@@ -278,7 +251,7 @@ class clonalisaGUI(QWidget):
             for root, _, files in os.walk(os.path.join(input_dir, sub)):
                 for f in files:
                     if f.lower().endswith('.tif'):
-                        well, _, _, _, _ = parse_filename(f)
+                        well, *_ = parse_filename(f)
                         if well:
                             wells.add(well)
                 break
@@ -286,151 +259,163 @@ class clonalisaGUI(QWidget):
         self._update_grid()
 
     def _index_to_well(self, row: int, col: int) -> str:
-        return f"{chr(ord('A')+row)}{col+1}"
+        return f"{chr(ord('A') + row)}{col + 1}"
 
-    def _update_grid(self) -> None:
+    def _update_grid(self):
         plate = self.plate_combo.currentText()
         if not plate:
             return
-        view = self.view_combo.currentText()
+
+        view  = self.view_combo.currentText()
         wells = self.plate_wells.get(plate, set())
+
         for r in range(8):
             for c in range(12):
                 item = self.table.item(r, c)
-                if item is None:
+                if item is None:                          
                     item = QTableWidgetItem()
                     self.table.setItem(r, c, item)
+
                 well = self._index_to_well(r, c)
-                item.setText("")
+                item.setText("")                          
+
                 if view == "Imaged Wells":
-                    color = QColor("lightgreen") if well in wells else QColor("lightgray")
-                    item.setBackground(color)
+                    item.setBackground(
+                        QColor("lightgreen" if well in wells else "lightgray")
+                    )
                 else:
                     mapping = self.group_data.get(plate, {}).get(view, {})
-                    val = mapping.get(well)
+                    val     = mapping.get(well)
                     if val is not None:
-                        item.setBackground(QColor("lightblue"))
+                        bg = self._color_for_value(val)
+                        item.setBackground(bg)
+
+                        # pick black/white text for readability
+                        luminance = 0.299*bg.redF() + 0.587*bg.greenF() + 0.114*bg.blueF()
+                        fg = QColor("black" if luminance > 0.6 else "white")
+                        item.setForeground(fg)
+
                         item.setText(str(val))
                     else:
-                        item.setBackground(QColor("white"))
+                        item.setBackground(QColor("transparent"))
+                        item.setText("")
 
-    def _new_group(self) -> None:
+
+    # -- groups ---------------------------------------------------------------
+    def _new_group(self):
         name, ok = QInputDialog.getText(self, "New Group", "Group name:")
-        if ok and name:
-            if self.group_combo.findText(name) == -1:
-                self.group_combo.addItem(name)
-                self.view_combo.addItem(name)
+        if ok and name and self.view_combo.findText(name) == -1:
+            self.view_combo.addItem(name)
+            # jump straight to the new group so the user can start tagging wells
+            self.view_combo.setCurrentText(name)
 
-    def _apply_group(self) -> None:
+    def _apply_group(self):
         plate = self.plate_combo.currentText()
-        group = self.group_combo.currentText()
+        group = self.view_combo.currentText()
         value = self.value_edit.text()
-        if not plate or not group or not value:
+
+        # don’t let the user scribble on the default “Imaged Wells” layer
+        if group == "Imaged Wells" or not (plate and group and value):
             return
+
         sel = self.table.selectedIndexes()
         if not sel:
             return
+
         mapping = self.group_data.setdefault(plate, {}).setdefault(group, {})
         for idx in sel:
-            well = self._index_to_well(idx.row(), idx.column())
-            mapping[well] = value
+            mapping[self._index_to_well(idx.row(), idx.column())] = value
+
         self.value_edit.clear()
         self._update_grid()
 
-    def _save_group_map(self) -> None:
+    def _save_group_map(self):
         folder = self.inp_edit.text()
         if not folder:
             return
         rows = []
         for plate, groups in self.group_data.items():
-            wells = set()
-            for g in groups.values():
-                wells.update(g.keys())
+            wells = {w for g in groups.values() for w in g}
             for well in wells:
                 row = {"Plate": plate.replace("plate", ""), "Well": well}
                 for gname, mapping in groups.items():
                     row[gname] = mapping.get(well)
                 rows.append(row)
         if rows:
-            df = pd.DataFrame(rows)
-            df.to_csv(os.path.join(folder, "group_map.csv"), index=False)
+            pd.DataFrame(rows).to_csv(Path(folder) / "group_map.csv", index=False)
             self._append_log("Saved group_map.csv")
         else:
             self._append_log("No groups to save")
 
-    def _open_config(self) -> None:
+    # -- config ---------------------------------------------------------------
+    def _open_config(self):
         dlg = ConfigDialog(self)
         if dlg.exec() == QDialog.Accepted:
             dlg.save()
             self.cfg = load_config()
             self._refresh_model_combo()
-    def _run_pipeline(self) -> None:
-        input_dir = self.inp_edit.text()
-        model_file = self.model_combo.currentText()
-        if not Path(input_dir).is_dir():
+
+    # -- pipeline -------------------------------------------------------------
+    def _run_pipeline(self):
+        input_dir  = Path(self.inp_edit.text())
+        model_file = Path(self.model_combo.currentText())
+        if not input_dir.is_dir():
             self._append_log("Invalid input directory")
             return
-        if not Path(model_file).is_file():
+        if not model_file.is_file():
             self._append_log("Model file not found")
             return
 
-        filt = self.filt_edit.text().strip() or "bright"
-        z_text = self.z_edit.text().strip()
-        z_indices = [int(i) for i in z_text.split(',') if i.strip().isdigit()] if z_text else None
+        filt       = self.filt_edit.text() or "bright"
+        z_indices  = [int(z) for z in self.z_edit.text().split(',') if z.strip().isdigit()] \
+                     if self.z_edit.text().strip() else None
+        flow_thr   = float(self.flow_edit.text() or 0)
+        mask_thr   = float(self.mask_edit.text() or 0)
 
-        flow_thr = float(self.flow_edit.text() or 0)
-        mask_thr = float(self.mask_edit.text() or 0)
+        self._append_log("Running Omnipose…")
+        model_info = (str(model_file), flow_thr, mask_thr)
 
-        self._append_log("Running Omnipose...")
-        model_info = (model_file, flow_thr, mask_thr)
-        for sub in os.listdir(input_dir):
-            sub_path = os.path.join(input_dir, sub)
-            if not os.path.isdir(sub_path) or "epoch" in sub:
-                continue
-            out_dir = omnipose_threaded.run_omnipose(
-                sub_path,
-                model_info,
-                num_threads=MAX_WORKERS,
-                filter_keyword=filt,
-                z_indices=z_indices,
-                save_flows=self.cb_flows.isChecked(),
-                save_cellProb=self.cb_cellprob.isChecked(),
-                save_outlines=self.cb_outlines.isChecked(),
-            )
-            process_masks.process_mask_files(
-                out_dir,
-                CM_PER_PIXEL,
-                PLATE_AREAS.get(PLATE_TYPE),
-                force_save=False,
-                filter_min_size=None,
-            )
-        all_csv = process_masks.make_all_data_csv(input_dir, os.path.basename(model_info[0]))
+        for sub in input_dir.iterdir():
+            if sub.is_dir() and "epoch" not in sub.name:
+                out_dir = omnipose_threaded.run_omnipose(
+                    str(sub), model_info, num_threads=MAX_WORKERS,
+                    filter_keyword=filt, z_indices=z_indices,
+                    save_flows=self.cb_flows.isChecked(),
+                    save_cellProb=self.cb_cellprob.isChecked(),
+                    save_outlines=self.cb_outlines.isChecked(),
+                )
+                process_masks.process_mask_files(
+                    out_dir, CM_PER_PIXEL, PLATE_AREAS.get(PLATE_TYPE),
+                    force_save=False, filter_min_size=None,
+                )
+
+        all_csv = process_masks.make_all_data_csv(str(input_dir), model_file.name)
         if all_csv:
             self.csv_edit.setText(all_csv)
             self._append_log(f"Created {all_csv}")
         self._append_log("Finished Omnipose pipeline")
 
         entry = {
-            'path': model_file,
-            'flow_threshold': flow_thr,
-            'mask_threshold': mask_thr,
-            'z_indices': z_indices or [],
+            'path': str(model_file), 'flow_threshold': flow_thr,
+            'mask_threshold': mask_thr, 'z_indices': z_indices or [],
         }
-        existing = [e for e in self.cfg.get('model_history', []) if e['path'] != model_file]
-        self.cfg['model_history'] = [entry] + existing
+        self.cfg['model_history'] = [entry] + [
+            e for e in self.cfg.get('model_history', []) if e['path'] != str(model_file)
+        ]
         save_config(self.cfg)
         self._refresh_model_combo()
 
-    def _run_rscript(self) -> None:
-        csv_path = self.csv_edit.text()
-        if not Path(csv_path).is_file():
+    # -- R analysis -----------------------------------------------------------
+    def _run_rscript(self):
+        csv_path = Path(self.csv_edit.text())
+        if not csv_path.is_file():
             self._append_log("Select a valid CSV file")
             return
         script = Path(__file__).with_name("interaction.R")
-        cmd = ["Rscript", str(script), csv_path]
-        self._append_log("Running Growth Rate Analysis R script...")
+        self._append_log("Running Growth-Rate Analysis R script…")
         try:
-            out = subprocess.run(cmd, capture_output=True, text=True, check=True)
+            out = subprocess.run(["Rscript", str(script), str(csv_path)],
+                                 capture_output=True, text=True, check=True)
             self._append_log(out.stdout)
             if out.stderr:
                 self._append_log(out.stderr)
@@ -439,13 +424,14 @@ class clonalisaGUI(QWidget):
             self._append_log(f"R script failed: {e}\n{e.stdout}\n{e.stderr}")
 
 
-def main() -> None:
-    app = QApplication([])
-    gui = clonalisaGUI()
+# -----------------------------------------------------------------------------
+def main():
+    app = QApplication(sys.argv)
+    enable_dark_palette(app)
+    gui = ClonaLiSAGUI()
     gui.show()
-    app.exec()
+    sys.exit(app.exec())
 
 
 if __name__ == "__main__":
     main()
-

--- a/clonalisa_config.json
+++ b/clonalisa_config.json
@@ -3,7 +3,6 @@
     "file": "(?P<well>[A-Za-z]+\\d+)_pos(?P<position>\\d+)Z(?P<z_index>\\d+)_(?P<channel>[^_]+(?: [^_]+)*)_\\d+_\\d+_(?P<step>\\d+)",
     "time_from_folder": ".*_(?P<date>\\d{8})_(?P<time>\\d{6})$"
   },
-  "time_source": "folder",
   "model_history": [
     {
       "path": "omnipose_models/10x_NPC_nclasses_2_nchan_3_dim_2_2024_03_29_02_03_10.875324_epoch_960",

--- a/clonalisa_ui.ui
+++ b/clonalisa_ui.ui
@@ -1,0 +1,512 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>ClonaLiSAForm</class>
+ <widget class="QWidget" name="ClonaLiSAForm">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>1600</width>
+    <height>900</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>ClonaLiSA</string>
+  </property>
+  <layout class="QHBoxLayout" name="topHLayout" stretch="0">
+   <item>
+    <widget class="QSplitter" name="mainSplitter">
+     <property name="enabled">
+      <bool>true</bool>
+     </property>
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="minimumSize">
+      <size>
+       <width>0</width>
+       <height>0</height>
+      </size>
+     </property>
+     <property name="baseSize">
+      <size>
+       <width>0</width>
+       <height>0</height>
+      </size>
+     </property>
+     <property name="orientation">
+      <enum>Qt::Orientation::Horizontal</enum>
+     </property>
+     <widget class="QWidget" name="leftBar">
+      <layout class="QVBoxLayout" name="leftVBox" stretch="0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0">
+       <item>
+        <layout class="QHBoxLayout" name="horizontalLayout_4"/>
+       </item>
+       <item>
+        <widget class="QPushButton" name="btnConfig">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="text">
+          <string>Config</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <layout class="QHBoxLayout" name="layoutInput">
+         <property name="bottomMargin">
+          <number>20</number>
+         </property>
+         <item>
+          <widget class="QLabel" name="labelInput">
+           <property name="text">
+            <string>Input directory:</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QLineEdit" name="inp_edit"/>
+         </item>
+         <item>
+          <widget class="QPushButton" name="btnBrowseInput">
+           <property name="text">
+            <string>Browse</string>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </item>
+       <item>
+        <layout class="QHBoxLayout" name="layoutPlate">
+         <item>
+          <widget class="QLabel" name="labelPlate">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="text">
+            <string>Plate:</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QComboBox" name="plate_combo">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </item>
+       <item>
+        <layout class="QHBoxLayout" name="layoutGroup">
+         <item>
+          <widget class="QPushButton" name="btnNewGroup">
+           <property name="text">
+            <string>New Group</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QComboBox" name="view_combo">
+           <item>
+            <property name="text">
+             <string>Imaged Wells</string>
+            </property>
+           </item>
+          </widget>
+         </item>
+         <item>
+          <widget class="QLineEdit" name="value_edit">
+           <property name="placeholderText">
+            <string>Value</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QPushButton" name="btnApplyGroup">
+           <property name="text">
+            <string>Apply</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QPushButton" name="btnSaveGroups">
+           <property name="text">
+            <string>Save Groups</string>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </item>
+       <item>
+        <widget class="QTableWidget" name="table">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="minimumSize">
+          <size>
+           <width>0</width>
+           <height>0</height>
+          </size>
+         </property>
+         <property name="sizeAdjustPolicy">
+          <enum>QAbstractScrollArea::SizeAdjustPolicy::AdjustIgnored</enum>
+         </property>
+         <property name="alternatingRowColors">
+          <bool>false</bool>
+         </property>
+         <property name="rowCount">
+          <number>8</number>
+         </property>
+         <property name="columnCount">
+          <number>12</number>
+         </property>
+         <attribute name="horizontalHeaderCascadingSectionResizes">
+          <bool>false</bool>
+         </attribute>
+         <attribute name="horizontalHeaderMinimumSectionSize">
+          <number>30</number>
+         </attribute>
+         <attribute name="horizontalHeaderDefaultSectionSize">
+          <number>30</number>
+         </attribute>
+         <attribute name="horizontalHeaderStretchLastSection">
+          <bool>false</bool>
+         </attribute>
+         <attribute name="verticalHeaderMinimumSectionSize">
+          <number>20</number>
+         </attribute>
+         <attribute name="verticalHeaderDefaultSectionSize">
+          <number>20</number>
+         </attribute>
+         <row/>
+         <row/>
+         <row/>
+         <row/>
+         <row/>
+         <row/>
+         <row/>
+         <row/>
+         <column/>
+         <column/>
+         <column/>
+         <column/>
+         <column/>
+         <column/>
+         <column/>
+         <column/>
+         <column/>
+         <column/>
+         <column/>
+         <column/>
+        </widget>
+       </item>
+       <item>
+        <spacer name="verticalSpacer_3">
+         <property name="orientation">
+          <enum>Qt::Orientation::Vertical</enum>
+         </property>
+         <property name="sizeType">
+          <enum>QSizePolicy::Policy::Fixed</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>40</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+       <item>
+        <layout class="QHBoxLayout" name="layoutModel">
+         <property name="topMargin">
+          <number>0</number>
+         </property>
+         <item>
+          <widget class="QLabel" name="labelModel">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="text">
+            <string>Model:</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QComboBox" name="model_combo">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="editable">
+            <bool>true</bool>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QPushButton" name="btnBrowseModel">
+           <property name="text">
+            <string>Browse</string>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </item>
+       <item>
+        <layout class="QHBoxLayout" name="layoutThresholds">
+         <item>
+          <widget class="QLabel" name="labelFlowThr">
+           <property name="text">
+            <string>Flow thr:</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QLineEdit" name="flow_edit"/>
+         </item>
+         <item>
+          <widget class="QLabel" name="labelMaskThr">
+           <property name="text">
+            <string>Mask thr:</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QLineEdit" name="mask_edit"/>
+         </item>
+        </layout>
+       </item>
+       <item>
+        <layout class="QHBoxLayout" name="layoutFilter">
+         <item>
+          <widget class="QLabel" name="labelFilter">
+           <property name="text">
+            <string>Filter keyword:</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QLineEdit" name="filt_edit">
+           <property name="text">
+            <string>bright</string>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </item>
+       <item>
+        <layout class="QHBoxLayout" name="layoutZ">
+         <item>
+          <widget class="QLabel" name="labelZ">
+           <property name="text">
+            <string>Z indices (comma separated):</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QLineEdit" name="z_edit">
+           <property name="text">
+            <string>0,1,2</string>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </item>
+       <item>
+        <layout class="QHBoxLayout" name="horizontalLayout_3"/>
+       </item>
+       <item>
+        <layout class="QHBoxLayout" name="horizontalLayout">
+         <item>
+          <widget class="QPushButton" name="btnRunOmnipose">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="text">
+            <string>Run Omnipose</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <layout class="QVBoxLayout" name="verticalLayout">
+           <property name="spacing">
+            <number>0</number>
+           </property>
+           <property name="sizeConstraint">
+            <enum>QLayout::SizeConstraint::SetDefaultConstraint</enum>
+           </property>
+           <property name="topMargin">
+            <number>0</number>
+           </property>
+           <item>
+            <widget class="QCheckBox" name="cb_outlines">
+             <property name="text">
+              <string>Save outlines</string>
+             </property>
+             <property name="checked">
+              <bool>true</bool>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QCheckBox" name="cb_cellprob">
+             <property name="text">
+              <string>Save cell prob</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QCheckBox" name="cb_flows">
+             <property name="text">
+              <string>Save flows</string>
+             </property>
+            </widget>
+           </item>
+          </layout>
+         </item>
+        </layout>
+       </item>
+       <item>
+        <spacer name="verticalSpacer_2">
+         <property name="orientation">
+          <enum>Qt::Orientation::Vertical</enum>
+         </property>
+         <property name="sizeType">
+          <enum>QSizePolicy::Policy::Fixed</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>40</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+       <item>
+        <layout class="QHBoxLayout" name="layoutCSV">
+         <property name="topMargin">
+          <number>0</number>
+         </property>
+         <item>
+          <widget class="QLabel" name="labelCSV">
+           <property name="text">
+            <string>all_data_csv:</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QLineEdit" name="csv_edit"/>
+         </item>
+         <item>
+          <widget class="QPushButton" name="btnBrowseCSV">
+           <property name="text">
+            <string>Browse</string>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </item>
+       <item>
+        <widget class="QPushButton" name="btnRunR">
+         <property name="minimumSize">
+          <size>
+           <width>0</width>
+           <height>50</height>
+          </size>
+         </property>
+         <property name="text">
+          <string>Run Growth Rate Analysis in R</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <spacer name="verticalSpacer">
+         <property name="orientation">
+          <enum>Qt::Orientation::Vertical</enum>
+         </property>
+         <property name="sizeType">
+          <enum>QSizePolicy::Policy::Fixed</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>40</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+       <item>
+        <widget class="QLabel" name="label">
+         <property name="text">
+          <string>Output:</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QTextEdit" name="log">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="minimumSize">
+          <size>
+           <width>0</width>
+           <height>100</height>
+          </size>
+         </property>
+         <property name="maximumSize">
+          <size>
+           <width>16777215</width>
+           <height>100</height>
+          </size>
+         </property>
+         <property name="readOnly">
+          <bool>true</bool>
+         </property>
+        </widget>
+       </item>
+      </layout>
+     </widget>
+     <widget class="QWidget" name="rightPanel">
+      <layout class="QVBoxLayout" name="rightVBox" stretch="0">
+       <item>
+        <widget class="Line" name="line">
+         <property name="orientation">
+          <enum>Qt::Orientation::Horizontal</enum>
+         </property>
+        </widget>
+       </item>
+      </layout>
+     </widget>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/config_utils.py
+++ b/config_utils.py
@@ -11,7 +11,6 @@ DEFAULT_CONFIG = {
         "file": r"(?P<well>[A-Za-z]+\d+)_pos(?P<position>\d+)(?:_(?P<channel>[^_]+))?(?:_Z(?P<z_index>\d+))?(?:_s(?P<step>\d+))?",
         "time_from_folder": r".*_(?P<date>\d{8})_(?P<time>\d{6})$",
     },
-    "time_source": "folder",
     "model_history": [
         {
             "path": str(Path('omnipose_models/10x_NPC_nclasses_2_nchan_3_dim_2_2024_03_29_02_03_10.875324_epoch_960')),
@@ -74,14 +73,7 @@ def extract_time_from_folder(folder_name, cfg=None):
 
 
 def get_image_time(image_path, cfg=None):
+    """Return the timestamp encoded in *image_path*'s parent folder."""
     if cfg is None:
         cfg = load_config()
-    source = cfg.get('time_source', 'folder')
-    if source == 'date_created':
-        try:
-            ts = Path(image_path).stat().st_birthtime
-            return datetime.fromtimestamp(ts)
-        except Exception:
-            return None
-    # fallback to folder name
     return extract_time_from_folder(Path(image_path).parent.name, cfg)

--- a/process_masks.py
+++ b/process_masks.py
@@ -647,14 +647,9 @@ def make_all_data_csv(input_folder, model_name=None):
                         times = []
                         for mask_fp in data['file_path']:
                             src_img = find_source_image(mask_fp)
-                            if cfg.get('time_source', 'folder') == 'date_created':
-                                t = get_image_time(src_img, cfg) if src_img else None
-                                if t is None:
-                                    t = folder_time
-                            else:
-                                t = folder_time
-                                if t is None and src_img:
-                                    t = get_image_time(src_img, cfg)
+                            t = folder_time
+                            if t is None and src_img:
+                                t = get_image_time(src_img, cfg)
                             times.append(t)
                         data['Time'] = times
                         all_data.append(data)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,8 @@ requires-python = ">=3.10"
 dependencies = [
   "omnipose @ git+https://github.com/kevinjohncutler/omnipose@8bc0db3e63bea26fd8f043ffe6fb1889e5b3a405",
   "statsmodels>=0.14,<0.16",
-   "shapely>=2.0,<3"
+  "shapely>=2.0,<3",
+  "pyside6"
 ]
 
 [tool.setuptools.packages.find]


### PR DESCRIPTION
## Summary
- remove `time_source` config and related logic
- always derive timestamps from folder names
- add plate selection and grouping controls to GUI
- generate `group_map.csv` from GUI annotations

## Testing
- `python -m py_compile clonalisa_GUI.py config_utils.py process_masks.py`

------
https://chatgpt.com/codex/tasks/task_e_683e2e85496483218487379fe62806d7