### PR TITLE
Add cell density view with time slider

### DIFF
--- a/clonalisa_ui.ui
+++ b/clonalisa_ui.ui
@@ -727,10 +727,17 @@
            <column/>
           </widget>
          </item>
-        </layout>
-       </item>
-      </layout>
-     </widget>
+         <item>
+          <widget class="QSlider" name="time_slider">
+           <property name="orientation">
+            <enum>Qt::Horizontal</enum>
+           </property>
+          </widget>
+         </item>
+         </layout>
+        </item>
+       </layout>
+      </widget>
     </widget>
    </item>
   </layout>


### PR DESCRIPTION
## Summary
- allow viewing cell density values in plate grid
- load cell density from selected CSV
- show a horizontal slider to switch between timepoints when multiple are present
- extend the UI with the slider widget

## Testing
- `python -m py_compile clonalisa_GUI.py`
- `python -m compileall -q .`
- *(failed: PySide6 could not load due to missing Qt libraries)*

------
https://chatgpt.com/codex/tasks/task_e_6840ee3dcfa88321b9c144de713a922e