### PR TITLE
Add flexible heatmap scaling and aggregation options

### DIFF
--- a/clonalisa_GUI.py
+++ b/clonalisa_GUI.py
@@ -25,7 +25,7 @@ from PySide6.QtGui import QPalette, QColor
 from PySide6.QtWidgets import QStyleFactory
 
 from colorsys import hsv_to_rgb
-import matplotlib.cm      as cm
+import matplotlib as mpl
 import matplotlib.colors  as mcolors
 
 def enable_dark_palette(app):
@@ -196,7 +196,7 @@ class ClonaLiSAGUI(QWidget):
 
         self.value_colors = {}          # { "treatmentA": QColor, ... }
         self._next_hue    = 0           # rolling hue pointer (0-359)
-        self._cmap = cm.get_cmap("viridis")
+        self._cmap = mpl.colormaps.get_cmap("viridis")
 
         # slider for timepoints
         self.time_slider.setVisible(False)
@@ -546,6 +546,7 @@ class ClonaLiSAGUI(QWidget):
 
     def _update_grid(self):
         plate = self.plate_combo.currentText()
+        plate_key = plate.lower()
         if not plate:
             return
 
@@ -568,7 +569,7 @@ class ClonaLiSAGUI(QWidget):
                         QColor("lightgreen" if well in wells else "lightgray")
                     )
                 elif view == "Cell Density":
-                    if not self.timepoints:
+                    if not self.timepoints or self.raw_cell_df is None:
                         mapping = {}
                         norm = None
                     else:

--- a/clonalisa_ui.ui
+++ b/clonalisa_ui.ui
@@ -588,91 +588,115 @@
        <item>
         <layout class="QVBoxLayout" name="layoutPlate">
          <item>
-          <layout class="QHBoxLayout" name="plate_selector">
+          <layout class="QHBoxLayout" name="plate_params">
            <item>
-            <widget class="QLabel" name="labelPlate">
-             <property name="sizePolicy">
-              <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-               <horstretch>0</horstretch>
-               <verstretch>0</verstretch>
-              </sizepolicy>
-             </property>
-             <property name="text">
-              <string>Plate:</string>
-             </property>
-            </widget>
-           </item>
-           <item>
-            <widget class="QComboBox" name="plate_combo">
-             <property name="sizePolicy">
-              <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-               <horstretch>0</horstretch>
-               <verstretch>0</verstretch>
-              </sizepolicy>
-             </property>
-            </widget>
-           </item>
-          </layout>
-         </item>
-         <item>
-          <layout class="QHBoxLayout" name="plate_grouping">
-           <item>
-            <widget class="QPushButton" name="btnNewGroup">
-             <property name="text">
-              <string>New Group</string>
-             </property>
-            </widget>
-           </item>
-           <item>
-            <widget class="QComboBox" name="view_combo">
+            <layout class="QVBoxLayout" name="plate_groups">
              <item>
-              <property name="text">
-               <string>Imaged Wells</string>
-              </property>
+              <layout class="QHBoxLayout" name="plate_selector">
+               <item>
+                <widget class="QLabel" name="labelPlate">
+                 <property name="sizePolicy">
+                  <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+                   <horstretch>0</horstretch>
+                   <verstretch>0</verstretch>
+                  </sizepolicy>
+                 </property>
+                 <property name="text">
+                  <string>Plate:</string>
+                 </property>
+                </widget>
+               </item>
+               <item>
+                <widget class="QComboBox" name="plate_combo">
+                 <property name="sizePolicy">
+                  <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+                   <horstretch>0</horstretch>
+                   <verstretch>0</verstretch>
+                  </sizepolicy>
+                 </property>
+                </widget>
+               </item>
+              </layout>
              </item>
-            </widget>
+             <item>
+              <layout class="QHBoxLayout" name="group_params">
+               <item>
+                <widget class="QPushButton" name="btnNewGroup">
+                 <property name="text">
+                  <string>New Group</string>
+                 </property>
+                </widget>
+               </item>
+               <item>
+                <widget class="QComboBox" name="view_combo">
+                 <item>
+                  <property name="text">
+                   <string>Imaged Wells</string>
+                  </property>
+                 </item>
+                </widget>
+               </item>
+               <item>
+                <widget class="QLineEdit" name="value_edit">
+                 <property name="placeholderText">
+                  <string>Value</string>
+                 </property>
+                </widget>
+               </item>
+               <item>
+                <widget class="QPushButton" name="btnApplyGroup">
+                 <property name="text">
+                  <string>Apply</string>
+                 </property>
+                </widget>
+               </item>
+               <item>
+                <widget class="QPushButton" name="btnSaveGroups">
+                 <property name="text">
+                  <string>Save Groups</string>
+                 </property>
+                </widget>
+               </item>
+              </layout>
+             </item>
+            </layout>
            </item>
            <item>
-            <widget class="QLineEdit" name="value_edit">
-             <property name="placeholderText">
-              <string>Value</string>
-             </property>
-            </widget>
-           </item>
-           <item>
-            <widget class="QPushButton" name="btnApplyGroup">
-             <property name="text">
-              <string>Apply</string>
-             </property>
-            </widget>
-           </item>
-           <item>
-            <widget class="QPushButton" name="btnSaveGroups">
-             <property name="text">
-              <string>Save Groups</string>
-             </property>
-            </widget>
-           </item>
-          </layout>
-         </item>
-         <item>
-          <layout class="QHBoxLayout" name="heatmap_options">
-           <item>
-            <widget class="QComboBox" name="agg_combo">
-             <item><property name="text"><string>Mean per Well</string></property></item>
-             <item><property name="text"><string>Median per Well</string></property></item>
-             <item><property name="text"><string>Per Position</string></property></item>
-            </widget>
-           </item>
-           <item>
-            <widget class="QCheckBox" name="cb_share_time">
-             <property name="text"><string>Share scale across timepoints</string></property>
-            </widget>
-           </item>
-           <item>
-            <widget class="QCheckBox" name="cb_share_plate">
-             <property name="text"><string>Share scale across plates</string></property>
-            </widget>
+            <layout class="QVBoxLayout" name="view_options">
+             <item>
+              <widget class="QComboBox" name="agg_combo">
+               <item>
+                <property name="text">
+                 <string>Mean per Well</string>
+                </property>
+               </item>
+               <item>
+                <property name="text">
+                 <string>Median per Well</string>
+                </property>
+               </item>
+               <item>
+                <property name="text">
+                 <string>Per Position</string>
+                </property>
+               </item>
+              </widget>
+             </item>
+             <item>
+              <widget class="QCheckBox" name="cb_share_plate">
+               <property name="text">
+                <string>Share scale across plates</string>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <widget class="QCheckBox" name="cb_share_time">
+               <property name="text">
+                <string>Share scale across timepoints</string>
+               </property>
+              </widget>
+             </item>
+            </layout>
            </item>
           </layout>
          </item>
@@ -751,14 +775,14 @@
          <item>
           <widget class="QSlider" name="time_slider">
            <property name="orientation">
-            <enum>Qt::Horizontal</enum>
+            <enum>Qt::Orientation::Horizontal</enum>
            </property>
           </widget>
          </item>
-         </layout>
-        </item>
-       </layout>
-      </widget>
+        </layout>
+       </item>
+      </layout>
+     </widget>
     </widget>
    </item>
   </layout>

--- a/clonalisa_ui.ui
+++ b/clonalisa_ui.ui
@@ -656,6 +656,27 @@
           </layout>
          </item>
          <item>
+          <layout class="QHBoxLayout" name="heatmap_options">
+           <item>
+            <widget class="QComboBox" name="agg_combo">
+             <item><property name="text"><string>Mean per Well</string></property></item>
+             <item><property name="text"><string>Median per Well</string></property></item>
+             <item><property name="text"><string>Per Position</string></property></item>
+            </widget>
+           </item>
+           <item>
+            <widget class="QCheckBox" name="cb_share_time">
+             <property name="text"><string>Share scale across timepoints</string></property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QCheckBox" name="cb_share_plate">
+             <property name="text"><string>Share scale across plates</string></property>
+            </widget>
+           </item>
+          </layout>
+         </item>
+         <item>
           <widget class="QTableWidget" name="table">
            <property name="sizePolicy">
             <sizepolicy hsizetype="Expanding" vsizetype="Expanding">


### PR DESCRIPTION
## Summary
- add controls for aggregation and heatmap scaling to GUI
- compute aggregated cell density values on demand
- reuse heatmap colouring for numeric values
- ignore model output folders when detecting plates

## Testing
- `python -m py_compile clonalisa_GUI.py process_masks.py plotting.py config_utils.py`

------
https://chatgpt.com/codex/tasks/task_e_6841ec6ec5c88321b0808f7b87f81d40